### PR TITLE
Refactor: Access Token 전달 방법 2차 수정

### DIFF
--- a/src/main/java/com/trip/aslung/config/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/trip/aslung/config/OAuth2LoginSuccessHandler.java
@@ -69,7 +69,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         cookie.setPath("/");
         cookie.setHttpOnly(false);
         cookie.setMaxAge(60*60); // 1시간(토큰 만료시간)
-        cookie.setSecure(true);
+        //cookie.setSecure(true); // 배포시 true
 
         response.addCookie(cookie);
     }


### PR DESCRIPTION
## 📌관련 이슈
- closed: #5 
## 💥작업 내용
- [x] AuthController 로직 수정: 토큰 발급 후 응답 헤더(Set-Cookie) 설정 변경
- [x] CookieUtil (또는 TokenProvider) 속성 변경: `HttpOnly`, `Secure`, `SameSite` 속성 적용 확인
- [x] CORS 설정 확인 (필요 시): 프론트엔드 도메인에 대해 `allowCredentials` 허용 여부 체크

## ✨ 참고 사항
- 프론트엔드에서는 별도의 헤더 파싱 없이 브라우저 쿠키에 자동 저장되는지 확인 부탁드립니다.
- 로컬 테스트 환경과 배포 환경(HTTPS)에서의 쿠키 동작 차이를 유의해주세요.
