### PR TITLE
Feature: 선호도조사 저장 API

### DIFF
--- a/src/main/java/com/trip/aslung/config/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/trip/aslung/config/OAuth2LoginSuccessHandler.java
@@ -62,7 +62,6 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         if(hasPreferences){
             log.info("기존 회원 -> 메인 페이지 이동");
             targetUrl = UriComponentsBuilder.fromUriString(frontUrl)
-                    .path("/main")
                     .build().toUriString();
         } else {
             log.info("신규/미조사 회원 -> 설문조사 페이지 이동");

--- a/src/main/java/com/trip/aslung/user/controller/UserController.java
+++ b/src/main/java/com/trip/aslung/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.trip.aslung.user.controller;
 import com.trip.aslung.user.model.dto.User;
 import com.trip.aslung.user.model.dto.UserStatsResponse;
 import com.trip.aslung.user.model.dto.UserUpdateRequest;
+import com.trip.aslung.user.model.service.UserPreferenceService;
 import com.trip.aslung.user.model.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/trip/aslung/user/controller/UserPreferenceController.java
+++ b/src/main/java/com/trip/aslung/user/controller/UserPreferenceController.java
@@ -1,0 +1,28 @@
+package com.trip.aslung.user.controller;
+
+import com.trip.aslung.user.model.dto.PreferenceRequest;
+import com.trip.aslung.user.model.service.UserPreferenceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/api/v1/user/preferences")
+@RequiredArgsConstructor
+public class UserPreferenceController {
+
+    private final UserPreferenceService userPreferenceService;
+
+    @PostMapping
+    public ResponseEntity<String> savePreferences(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody PreferenceRequest requestDto){
+        userPreferenceService.savePreference(userId, requestDto);
+
+        return ResponseEntity.ok("선호도 조사 저장 완료");
+    }
+}

--- a/src/main/java/com/trip/aslung/user/model/dto/PreferenceRequest.java
+++ b/src/main/java/com/trip/aslung/user/model/dto/PreferenceRequest.java
@@ -1,0 +1,15 @@
+package com.trip.aslung.user.model.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PreferenceRequest {
+    private String travelStyle;
+    private String pace;
+    private List<String> interestKeywords;
+}

--- a/src/main/java/com/trip/aslung/user/model/service/UserPreferenceService.java
+++ b/src/main/java/com/trip/aslung/user/model/service/UserPreferenceService.java
@@ -1,0 +1,8 @@
+package com.trip.aslung.user.model.service;
+
+import com.trip.aslung.user.model.dto.PreferenceRequest;
+import com.trip.aslung.user.model.dto.UserPreferences;
+
+public interface UserPreferenceService {
+    void savePreference(Long userId, PreferenceRequest requestDto);
+}

--- a/src/main/java/com/trip/aslung/user/model/service/UserPreferenceServiceImpl.java
+++ b/src/main/java/com/trip/aslung/user/model/service/UserPreferenceServiceImpl.java
@@ -1,0 +1,42 @@
+package com.trip.aslung.user.model.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trip.aslung.user.model.dto.PreferenceRequest;
+import com.trip.aslung.user.model.dto.UserPreferences;
+import com.trip.aslung.user.model.mapper.UserPreferencesMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserPreferenceServiceImpl implements UserPreferenceService{
+
+    private final UserPreferencesMapper userPreferencesMapper;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    @Transactional
+    public void savePreference(Long userId, PreferenceRequest requestDto) {
+        // 키워드 리스트 -> JSON 문자열 변환
+        String keywordsJson = "[]";
+        try {
+            if (requestDto.getInterestKeywords() != null) {
+                keywordsJson = objectMapper.writeValueAsString(requestDto.getInterestKeywords());
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("JSON 변환 오류", e);
+        };
+
+        UserPreferences userPreferences = UserPreferences.builder()
+                .userId(userId)
+                .travelStyle(requestDto.getTravelStyle())
+                .pace(requestDto.getPace())
+                .interestKeywords(keywordsJson)
+                .build();
+
+        if(!userPreferencesMapper.existsByUserId(userId)){
+            userPreferencesMapper.insertUserPreferences(userPreferences);
+        }
+    }
+}


### PR DESCRIPTION
## 📌관련 이슈

- closed: #11

## 💥작업 내용

- 사용자 여행 취향 수정 API (`POST /api/v1/user/preferences`) 구현
- `PreferenceRequest` DTO 생성 및 매핑 로직 추가
- 데이터 전송 방식을 `application/json`으로 처리 (`@RequestBody` 적용)

## ✨참고 사항

- API 명세서 양식에 맞춰 응답 포맷 통일