### PR TITLE
Feature: 플랜 CRUD API

### DIFF
--- a/src/main/java/com/trip/aslung/plan/controller/PlanController.java
+++ b/src/main/java/com/trip/aslung/plan/controller/PlanController.java
@@ -1,0 +1,68 @@
+package com.trip.aslung.plan.controller;
+
+import com.trip.aslung.plan.model.dto.PlanCreateRequest;
+import com.trip.aslung.plan.model.dto.PlanDetailResponse;
+import com.trip.aslung.plan.model.dto.PlanListResponse;
+import com.trip.aslung.plan.model.dto.PlanUpdateRequest;
+import com.trip.aslung.plan.model.service.PlanService;
+import jakarta.websocket.server.PathParam;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/api/v1/plans")
+@RequiredArgsConstructor
+public class PlanController {
+
+    private final PlanService planService;
+
+    @GetMapping
+    public ResponseEntity<List<PlanListResponse>> getMyPlans(
+            @AuthenticationPrincipal Long userId
+    ){
+        List<PlanListResponse> myPlans = planService.getMyPlans(1L);
+        return ResponseEntity.ok(myPlans);
+    }
+
+    @PostMapping
+    public ResponseEntity<Long> createPlan(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody PlanCreateRequest request
+    ){
+        Long planId = planService.createPlan(userId, request);
+        return ResponseEntity.ok(planId);
+    }
+
+    @GetMapping("/{planId}")
+    public ResponseEntity<PlanDetailResponse> getPlanDetail(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable("planId") Long planId
+    ){
+        PlanDetailResponse planDetail = planService.getPlanDetail(userId, planId);
+        return ResponseEntity.ok(planDetail);
+    }
+
+    @PatchMapping("/{planId}")
+    public ResponseEntity<Void> updatePlan(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable(("planId")) Long planId,
+            @RequestBody PlanUpdateRequest request
+    ){
+        planService.updatePlan(userId, planId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{planId}")
+    public ResponseEntity<Void> deletePlan(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable(("planId")) Long planId
+    ){
+        planService.deletePlan(userId, planId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/trip/aslung/plan/model/dto/Plan.java
+++ b/src/main/java/com/trip/aslung/plan/model/dto/Plan.java
@@ -1,0 +1,45 @@
+package com.trip.aslung.plan.model.dto;
+
+import lombok.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class Plan {
+    private Long planId;
+    private Long userId;
+    private String title;
+    private String regionName;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Boolean isPublic;
+    private String shareUuid;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+
+    // DB 문자열 -> List로 변환해서 가져오기
+    public List<String> getRegionList() {
+        if (this.regionName == null || this.regionName.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList(this.regionName.split(","));
+    }
+
+    // List -> DB 문자열로 변환해서 세팅하기
+    public void setRegionList(List<String> regions) {
+        if (regions != null && !regions.isEmpty()) {
+            this.regionName = String.join(",", regions);
+        } else {
+            this.regionName = null;
+        }
+    }
+}

--- a/src/main/java/com/trip/aslung/plan/model/dto/PlanCreateRequest.java
+++ b/src/main/java/com/trip/aslung/plan/model/dto/PlanCreateRequest.java
@@ -1,0 +1,16 @@
+package com.trip.aslung.plan.model.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter @Setter
+@NoArgsConstructor
+public class PlanCreateRequest {
+    private List<String> regions;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Boolean isPublic;   // 공개 여부 (선택 사항, 안 보내면 false)
+}

--- a/src/main/java/com/trip/aslung/plan/model/dto/PlanDetailResponse.java
+++ b/src/main/java/com/trip/aslung/plan/model/dto/PlanDetailResponse.java
@@ -1,0 +1,29 @@
+package com.trip.aslung.plan.model.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import software.amazon.awssdk.services.s3.endpoints.internal.Value;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PlanDetailResponse {
+    // 1. 기본 정보
+    private Long planId;
+    private String title;
+    private String regionName;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Boolean isPublic;
+    private Long ownerId;
+
+    // 2. 멤버 목록
+    private List<PlanMember> members;
+
+    // 3. 일정 목록
+    private List<PlanSchedule> schedules;
+}

--- a/src/main/java/com/trip/aslung/plan/model/dto/PlanListResponse.java
+++ b/src/main/java/com/trip/aslung/plan/model/dto/PlanListResponse.java
@@ -1,0 +1,37 @@
+package com.trip.aslung.plan.model.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@Builder
+public class PlanListResponse {
+    private Long planId;
+    private String title;
+    private String regionName;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private boolean isPublic;
+    private Long ownerId;
+
+    // DB 문자열 -> List로 변환해서 가져오기
+    public List<String> getRegionList() {
+        if (this.regionName == null || this.regionName.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList(this.regionName.split(","));
+    }
+
+    // List -> DB 문자열로 변환해서 세팅하기
+    public void setRegionList(List<String> regions) {
+        if (regions != null && !regions.isEmpty()) {
+            this.regionName = String.join(",", regions);
+        } else {
+            this.regionName = null;
+        }
+    }
+}

--- a/src/main/java/com/trip/aslung/plan/model/dto/PlanMember.java
+++ b/src/main/java/com/trip/aslung/plan/model/dto/PlanMember.java
@@ -1,0 +1,19 @@
+package com.trip.aslung.plan.model.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlanMember {
+    private Long memberId;
+    private Long planId;
+    private Long userId;
+    private String role;        // OWNER, EDITOR, VIEWER
+    private String status;      // INVITED, JOINED
+    private LocalDateTime joinedAt;
+}

--- a/src/main/java/com/trip/aslung/plan/model/dto/PlanSchedule.java
+++ b/src/main/java/com/trip/aslung/plan/model/dto/PlanSchedule.java
@@ -1,0 +1,16 @@
+package com.trip.aslung.plan.model.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PlanSchedule {
+    private Long scheduleId;
+    private Long placeId;       // 장소 ID
+    private int dayNumber;      // 1일차, 2일차..
+    private int orderIndex;     // 순서
+    private String memo;        // 메모
+}

--- a/src/main/java/com/trip/aslung/plan/model/dto/PlanUpdateRequest.java
+++ b/src/main/java/com/trip/aslung/plan/model/dto/PlanUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.trip.aslung.plan.model.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PlanUpdateRequest {
+    private String title;
+    private List<String> regions;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Boolean isPublic;
+}

--- a/src/main/java/com/trip/aslung/plan/model/mapper/PlanMapper.java
+++ b/src/main/java/com/trip/aslung/plan/model/mapper/PlanMapper.java
@@ -1,0 +1,18 @@
+package com.trip.aslung.plan.model.mapper;
+
+import com.trip.aslung.plan.model.dto.*;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface PlanMapper {
+    List<PlanListResponse> selectMyPlans(Long userId);
+    PlanDetailResponse selectPlanDetail(@Param("planId") Long planId);
+    List<PlanMember> selectPlanMembers(Long planId);
+    List<PlanSchedule> selectPlanSchedules(Long planId);
+    void insertPlan(Plan plan);
+    void updatePlan(Plan plan);
+    void deletePlan(Long planId);
+}

--- a/src/main/java/com/trip/aslung/plan/model/mapper/PlanMemberMapper.java
+++ b/src/main/java/com/trip/aslung/plan/model/mapper/PlanMemberMapper.java
@@ -1,0 +1,12 @@
+package com.trip.aslung.plan.model.mapper;
+
+import com.trip.aslung.plan.model.dto.PlanMember;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.Map;
+
+@Mapper
+public interface PlanMemberMapper {
+    void insertPlanMember(PlanMember planMember);
+    PlanMember findByPlanIdAndUserId(Long planId, Long userId);
+}

--- a/src/main/java/com/trip/aslung/plan/model/service/PlanService.java
+++ b/src/main/java/com/trip/aslung/plan/model/service/PlanService.java
@@ -1,0 +1,16 @@
+package com.trip.aslung.plan.model.service;
+
+import com.trip.aslung.plan.model.dto.PlanCreateRequest;
+import com.trip.aslung.plan.model.dto.PlanDetailResponse;
+import com.trip.aslung.plan.model.dto.PlanListResponse;
+import com.trip.aslung.plan.model.dto.PlanUpdateRequest;
+
+import java.util.List;
+
+public interface PlanService {
+    List<PlanListResponse> getMyPlans(Long userId);
+    PlanDetailResponse getPlanDetail(Long userId, Long planId);
+    Long createPlan(Long userId, PlanCreateRequest request);
+    void updatePlan(Long userId, Long planId, PlanUpdateRequest request);
+    void deletePlan(Long userId, Long planId);
+}

--- a/src/main/java/com/trip/aslung/plan/model/service/PlanServiceImpl.java
+++ b/src/main/java/com/trip/aslung/plan/model/service/PlanServiceImpl.java
@@ -1,0 +1,138 @@
+package com.trip.aslung.plan.model.service;
+
+import com.trip.aslung.plan.model.dto.*;
+import com.trip.aslung.plan.model.mapper.PlanMapper;
+import com.trip.aslung.plan.model.mapper.PlanMemberMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class PlanServiceImpl implements PlanService {
+
+    private final PlanMapper planMapper;
+    private final PlanMemberMapper planMemberMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<PlanListResponse> getMyPlans(Long userId) {
+        return planMapper.selectMyPlans(userId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PlanDetailResponse getPlanDetail(Long userId, Long planId) {
+        // 1. 플랜 가져오기
+        PlanDetailResponse plan = planMapper.selectPlanDetail(planId);
+
+        if(plan==null){
+            throw new IllegalArgumentException("해당 플랜이 존재하지 않습니다.");
+        }
+
+        // 2. 멤버 조회
+        List<PlanMember> members = planMapper.selectPlanMembers(planId);
+
+        // 3. 권한 체크
+        boolean isOwner = plan.getOwnerId().equals(userId);
+        boolean isMember = members.stream()
+                .anyMatch(m -> m.getUserId().equals(userId) && "JOINED".equals(m.getStatus()));
+
+        if(!Boolean.TRUE.equals(plan.getIsPublic()) && !isMember && !isOwner){
+            throw new IllegalArgumentException("접근 권한이 없습니다");
+        }
+
+        // 4. 스케줄 조회
+        List<PlanSchedule> schedules = planMapper.selectPlanSchedules(planId);
+
+        plan.setMembers(members);
+        plan.setSchedules(schedules);
+
+        return plan;
+    }
+
+    @Override
+    @Transactional
+    public Long createPlan(Long userId, PlanCreateRequest request) {
+
+        // 1. 플랜 생성
+        Plan plan = new Plan();
+        plan.setUserId(userId);
+        if (request.getRegions() != null && !request.getRegions().isEmpty()) {
+            String regionsStr = String.join(",", request.getRegions());
+            plan.setRegionName(regionsStr);
+        }
+        plan.setTitle(request.getRegions() + " 여행");
+        plan.setStartDate(request.getStartDate());
+        plan.setEndDate(request.getEndDate());
+        plan.setIsPublic(request.getIsPublic() != null ? request.getIsPublic() : false);
+
+        // 2. 플랜 저장
+        planMapper.insertPlan(plan);
+        if(plan.getPlanId()==null){
+            throw new RuntimeException("플랜 생성 중 오류 발생");
+        }
+
+        // 3. 작성자 멤버 추가
+        PlanMember newMember = PlanMember.builder()
+                .planId(plan.getPlanId())
+                .userId(userId)
+                .role("OWNER")
+                .status("JOINED")
+                .joinedAt(LocalDateTime.now())
+                .build();
+        planMemberMapper.insertPlanMember(newMember);
+
+        return plan.getPlanId();
+    }
+
+    @Override
+    @Transactional
+    public void updatePlan(Long userId, Long planId, PlanUpdateRequest request) {
+        PlanMember member = planMemberMapper.findByPlanIdAndUserId(planId, userId);
+
+        // 권한 확인
+        if (member == null || !"OWNER".equals(member.getRole())) {
+            throw new AccessDeniedException("플랜 수정 권한이 없습니다. (작성자만 가능)");
+        }
+
+        // 날짜 예외처리
+        if (request.getStartDate() != null && request.getEndDate() != null) {
+            if (request.getStartDate().isAfter(request.getEndDate())) {
+                throw new IllegalArgumentException("종료일이 시작일보다 빠를 수 없습니다.");
+            }
+        }
+
+        Plan plan = new Plan();
+        plan.setPlanId(planId);
+        plan.setTitle(request.getTitle());
+        plan.setRegionList(request.getRegions());
+        plan.setStartDate(request.getStartDate());
+        plan.setEndDate(request.getEndDate());
+        plan.setIsPublic(request.getIsPublic());
+        plan.setUpdatedAt(LocalDateTime.now());
+
+        planMapper.updatePlan(plan);
+    }
+
+    @Override
+    @Transactional
+    public void deletePlan(Long userId, Long planId) {
+        // 권한 확인
+        PlanDetailResponse plan = planMapper.selectPlanDetail(planId);
+
+        if (plan == null) throw new IllegalArgumentException("플랜이 없습니다.");
+        if (!plan.getOwnerId().equals(userId)) {
+            throw new AccessDeniedException("작성자만 삭제할 수 있습니다.");
+        }
+
+        // 소프트 삭제 => 여행기 삭제 로직 필요
+        planMapper.deletePlan(planId);
+    }
+}

--- a/src/main/resources/mapper/Plan.xml
+++ b/src/main/resources/mapper/Plan.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.trip.aslung.plan.model.mapper.PlanMapper">
+
+    <select id="selectMyPlans" resultType="com.trip.aslung.plan.model.dto.PlanListResponse">
+        SELECT
+            p.plan_id     AS planId,
+            p.title       AS title,
+            p.region_name AS regionName,
+            p.start_date  AS startDate,
+            p.end_date    AS endDate,
+            p.is_public   AS isPublic,
+            p.user_id     AS ownerId
+        FROM plans p
+                 INNER JOIN plan_members m ON p.plan_id = m.plan_id
+        WHERE m.user_id = #{userId}
+          AND m.status = 'JOINED'
+          AND p.deleted_at IS NULL
+        ORDER BY p.created_at DESC
+    </select>
+
+    <select id="selectPlanDetail" resultType="com.trip.aslung.plan.model.dto.PlanDetailResponse">
+        SELECT
+            plan_id     AS planId,
+            user_id     AS ownerId,
+            title       AS title,
+            region_name AS regionName,
+            start_date  AS startDate,
+            end_date    AS endDate,
+            is_public   AS isPublic,
+            share_uuid  AS shareUuid
+        FROM plans
+        WHERE plan_id = #{planId}
+    </select>
+
+    <select id="selectPlanMembers" resultType="com.trip.aslung.plan.model.dto.PlanMember">
+        SELECT
+            member_id   AS memberId,
+            user_id     AS userId,
+            role        AS role,
+            status      AS status,
+            joined_at   AS joinedAt
+        FROM plan_members
+        WHERE plan_id = #{planId}
+        ORDER BY field(role, 'OWNER', 'EDITOR', 'VIEWER'), joined_at ASC
+    </select>
+
+    <select id="selectPlanSchedules" resultType="com.trip.aslung.plan.model.dto.PlanSchedule">
+        SELECT
+            schedule_id AS scheduleId,
+            place_id    AS placeId,
+            day_number  AS dayNumber,
+            order_index AS orderIndex,
+            memo        AS memo
+        FROM plan_schedules
+        WHERE plan_id = #{planId}
+        ORDER BY day_number ASC, order_index ASC
+    </select>
+
+    <insert id="insertPlan" useGeneratedKeys="true" keyProperty="planId" parameterType="com.trip.aslung.plan.model.dto.Plan">
+        INSERT INTO plans (
+            user_id,
+            title,
+            start_date,
+            end_date,
+            is_public
+        ) VALUES (
+                     #{userId},
+                     #{title},
+                     #{startDate},
+                     #{endDate},
+                     #{isPublic}
+                 )
+    </insert>
+
+    <update id="updatePlan" parameterType="com.trip.aslung.plan.model.dto.Plan">
+        UPDATE plans
+        <set>
+            <if test="title != null">title = #{title},</if>
+
+            <if test="regionName != null">region_name = #{regionName},</if>
+
+            <if test="startDate != null">start_date = #{startDate},</if>
+            <if test="endDate != null">end_date = #{endDate},</if>
+            <if test="isPublic != null">is_public = #{isPublic},</if>
+            <if test="updatedAt != null">updated_at = #{updatedAt},</if>
+        </set>
+        WHERE plan_id = #{planId}
+    </update>
+
+    <update id="deletePlan">
+        UPDATE plans
+        SET deleted_at = NOW()
+        WHERE plan_id = #{planId}
+          AND user_id = #{userId}
+    </update>
+</mapper>

--- a/src/main/resources/mapper/PlanMember.xml
+++ b/src/main/resources/mapper/PlanMember.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.trip.aslung.plan.model.mapper.PlanMemberMapper">
+    <insert id="insertPlanMember" parameterType="com.trip.aslung.plan.model.dto.PlanMember">
+        INSERT INTO plan_members (plan_id, user_id, role, status, joined_at)
+        VALUES (
+                   #{planId},
+                   #{userId},
+                   #{role},   #{status},
+                   #{joinedAt}
+               )
+    </insert>
+
+    <select id="findByPlanIdAndUserId" resultType="com.trip.aslung.plan.model.dto.PlanMember">
+        SELECT
+            member_id  AS memberId,
+            plan_id    AS planId,
+            user_id    AS userId,
+            role       AS role,
+            status     AS status,
+            joined_at  AS joinedAt
+        FROM plan_members
+        WHERE plan_id = #{planId}
+          AND user_id = #{userId}
+    </select>
+</mapper>


### PR DESCRIPTION
## 📌관련 이슈
- closed: #15
- 
## 💥작업 내용

**1. 여행 플랜(Plan) CRUD API 구현**

- **생성 (`POST`)**: 제목, 여행지(List), 날짜, 공개 여부를 받아 플랜 생성
- **목록 조회 (`GET`)**: 내가 생성한 플랜 목록 조회 (최신순)
- **상세 조회 (`GET`)**: 플랜 상세 정보, 멤버, 스케줄 포함 조회
- **수정 (`PATCH`)**: 방장(Owner)만 수정 가능, 변경된 필드만 업데이트 (Dynamic Query)
- **삭제 (`DELETE`)**: 방장(Owner)만 삭제 가능, **Soft Delete** 적용

**2. 권한 및 검증 로직 강화**

- **상세 조회 권한**: 비공개 플랜인 경우, 멤버(`JOINED`)이거나 방장인 경우에만 접근 허용
- **수정/삭제 권한**: `plans` 테이블의 `user_id`를 직접 조회하여 방장 본인 확인 (데이터 정합성 확보)
- **유효성 검사**: 종료일이 시작일보다 빠른 경우 예외 처리 (`IllegalArgumentException`)

**3. 데이터 변환 및 연관 처리**

- **지역 정보 처리**: `List<String>`(DTO) ↔ `String`(DB "서울,부산") 자동 변환 로직을 DTO 내부에 캡슐화
- **연쇄 삭제(Cascade Soft Delete)**: 플랜 삭제 시, 공유된 **게시글(Posts)**도 함께 `deleted_at` 처리되도록 로직 추가
- **버그 수정**: 컨트롤러 경로 변수 처리 시 `@PathParam` → `@PathVariable`로 수정하여 파라미터 바인딩 오류 해결

## ✨참고 사항
- 삭제 방식: DB 데이터를 지우지 않고 deleted_at에 타임스탬프를 찍는 논리적 삭제(Soft Delete) 방식입니다.
- 플랜 삭제 시, 해당 플랜과 연결된 **커뮤니티 게시글(Posts)**도 함께 삭제 로직 필요