### PR TITLE
Feature: 세부일정(schedules) CRUD API

### DIFF
--- a/src/main/java/com/trip/aslung/plan/controller/ScheduleController.java
+++ b/src/main/java/com/trip/aslung/plan/controller/ScheduleController.java
@@ -1,0 +1,64 @@
+package com.trip.aslung.plan.controller;
+
+import com.trip.aslung.plan.model.dto.PlanSchedule;
+import com.trip.aslung.plan.model.dto.ScheduleMoveRequest;
+import com.trip.aslung.plan.model.dto.ScheduleUpdateRequest;
+import com.trip.aslung.plan.model.service.PlanScheduleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/plans/{planId}/schedules")
+@RequiredArgsConstructor
+public class ScheduleController {
+
+    private final PlanScheduleService planScheduleService;
+
+    // 세부 일정 등록
+    @PostMapping
+    public ResponseEntity<Void> addSchedule(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long planId,
+            @RequestBody PlanSchedule request
+    ){
+        planScheduleService.addSchedule(userId, planId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    // 세부 일정 수정
+    @PatchMapping("/{scheduleId}")
+    public ResponseEntity<Void> updateSchedule(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long planId,
+            @PathVariable Long scheduleId,
+            @RequestBody ScheduleUpdateRequest request
+    ){
+        planScheduleService.updateSchedule(userId,planId,scheduleId,request);
+        return ResponseEntity.ok().build();
+    }
+
+    // 세부 일정 삭제
+    @DeleteMapping("/{scheduleId}")
+    public ResponseEntity<Void> deleteSchedule(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long planId,
+            @PathVariable Long scheduleId
+    ){
+        planScheduleService.deleteSchedule(userId,planId,scheduleId);
+        return ResponseEntity.ok().build();
+    }
+
+    // 순서 변경
+    @PatchMapping("/{scheduleId}/move")
+    public ResponseEntity<Void> moveScheduleOrder(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long planId,
+            @PathVariable Long scheduleId,
+            @RequestBody ScheduleMoveRequest request
+    ){
+        planScheduleService.moveSchedule(userId,planId,scheduleId,request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/trip/aslung/plan/model/dto/PlanSchedule.java
+++ b/src/main/java/com/trip/aslung/plan/model/dto/PlanSchedule.java
@@ -4,13 +4,19 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 @NoArgsConstructor
 public class PlanSchedule {
     private Long scheduleId;
+    private Long planId;
     private Long placeId;       // 장소 ID
     private int dayNumber;      // 1일차, 2일차..
     private int orderIndex;     // 순서
     private String memo;        // 메모
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/trip/aslung/plan/model/dto/ScheduleMoveRequest.java
+++ b/src/main/java/com/trip/aslung/plan/model/dto/ScheduleMoveRequest.java
@@ -1,0 +1,12 @@
+package com.trip.aslung.plan.model.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter
+@NoArgsConstructor
+public class ScheduleMoveRequest {
+    private int targetDay;
+    private int targetOrder;
+}

--- a/src/main/java/com/trip/aslung/plan/model/dto/ScheduleUpdateRequest.java
+++ b/src/main/java/com/trip/aslung/plan/model/dto/ScheduleUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.trip.aslung.plan.model.dto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter
+@NoArgsConstructor
+public class ScheduleUpdateRequest {
+    private Long placeId;
+    private String memo;
+}

--- a/src/main/java/com/trip/aslung/plan/model/mapper/PlanScheduleMapper.java
+++ b/src/main/java/com/trip/aslung/plan/model/mapper/PlanScheduleMapper.java
@@ -1,0 +1,19 @@
+package com.trip.aslung.plan.model.mapper;
+
+import com.trip.aslung.plan.model.dto.PlanSchedule;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface PlanScheduleMapper {
+
+    PlanSchedule findById(Long scheduleId);
+    void createSchedule(PlanSchedule planSchedule);
+    void updateSchedule(PlanSchedule planSchedule);
+    void deleteSchedule(Long scheduleId);
+    void pullScheduleOrders(Long planId, int dayNumber, int startOrder);
+    void pushScheduleOrders(Long planId, int dayNumber, int startOrder);
+    void moveOrderBack(Long planId, int day, int oldOrder, int newOrder);
+    void moveOrderFront(Long planId, int day, int oldOrder, int newOrder);
+    void updateScheduleDayAndOrder(PlanSchedule schedule);
+    int selectMaxOrderIndex(Long planId, int dayNumber);
+}

--- a/src/main/java/com/trip/aslung/plan/model/service/PlanScheduleService.java
+++ b/src/main/java/com/trip/aslung/plan/model/service/PlanScheduleService.java
@@ -1,0 +1,12 @@
+package com.trip.aslung.plan.model.service;
+
+import com.trip.aslung.plan.model.dto.PlanSchedule;
+import com.trip.aslung.plan.model.dto.ScheduleMoveRequest;
+import com.trip.aslung.plan.model.dto.ScheduleUpdateRequest;
+
+public interface PlanScheduleService {
+    void addSchedule(Long userId, Long planId, PlanSchedule request);
+    void updateSchedule(Long userId, Long planId, Long scheduleId, ScheduleUpdateRequest request);
+    void deleteSchedule(Long userId, Long planId, Long scheduleId);
+    void moveSchedule(Long userId, Long planId, Long scheduleId, ScheduleMoveRequest request);
+}

--- a/src/main/java/com/trip/aslung/plan/model/service/PlanScheduleServiceImpl.java
+++ b/src/main/java/com/trip/aslung/plan/model/service/PlanScheduleServiceImpl.java
@@ -1,0 +1,128 @@
+package com.trip.aslung.plan.model.service;
+
+import com.trip.aslung.plan.model.dto.PlanMember;
+import com.trip.aslung.plan.model.dto.PlanSchedule;
+import com.trip.aslung.plan.model.dto.ScheduleMoveRequest;
+import com.trip.aslung.plan.model.dto.ScheduleUpdateRequest;
+import com.trip.aslung.plan.model.mapper.PlanMemberMapper;
+import com.trip.aslung.plan.model.mapper.PlanScheduleMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class PlanScheduleServiceImpl implements PlanScheduleService{
+
+    private final PlanScheduleMapper planScheduleMapper;
+    private final PlanMemberMapper planMemberMapper;
+    @Override
+    public void addSchedule(Long userId, Long planId, PlanSchedule request) {
+        validatePermission(planId,userId);
+
+        request.setPlanId(planId);
+        planScheduleMapper.createSchedule(request);
+    }
+
+    @Override
+    public void updateSchedule(Long userId, Long planId, Long scheduleId, ScheduleUpdateRequest request) {
+        validatePermission(planId,userId);
+        log.info("[update] planId : {}, userId : {}, scheduleId : {}", userId, planId, scheduleId);
+        log.info("memo: {}, placeId:{}", request.getMemo(), request.getPlaceId());
+        PlanSchedule schedule = new PlanSchedule();
+        schedule.setScheduleId(scheduleId);
+        schedule.setPlanId(planId);
+        schedule.setPlaceId(request.getPlaceId());
+        schedule.setMemo(request.getMemo());
+        planScheduleMapper.updateSchedule(schedule);
+    }
+
+    @Override
+    public void deleteSchedule(Long userId, Long planId, Long scheduleId) {
+        validatePermission(planId,userId);
+
+        // 예외처리
+        PlanSchedule schedule = planScheduleMapper.findById(scheduleId);
+        if (schedule == null || !schedule.getPlanId().equals(planId)) {
+            throw new IllegalArgumentException("존재하지 않는 스케줄입니다.");
+        }
+
+        planScheduleMapper.deleteSchedule(scheduleId);
+
+        // 빈자리 메꾸기
+        planScheduleMapper.pullScheduleOrders(
+                planId,
+                schedule.getDayNumber(),
+                schedule.getOrderIndex()
+        );
+    }
+
+    @Override
+    public void moveSchedule(Long userId, Long planId, Long scheduleId, ScheduleMoveRequest request) {
+        // 1. 권한 체크 및 데이터 가져오기
+        validatePermission(planId, userId);
+        PlanSchedule schedule = planScheduleMapper.findById(scheduleId);
+
+        if (schedule == null || !schedule.getPlanId().equals(planId)) {
+            throw new IllegalArgumentException("잘못된 스케줄입니다.");
+        }
+
+        int currentDay = schedule.getDayNumber();
+        int currentOrder = schedule.getOrderIndex();
+
+        int newDay = request.getTargetDay();
+        int newOrder = request.getTargetOrder();
+
+        // 2. 같은 위치로 이동하는 거면 return
+        if (currentDay == newDay && currentOrder == newOrder) return;
+
+        // ==========================================
+        // 핵심 로직: 뽑고(Pull) -> 밀고(Push) -> 넣기
+        // ==========================================
+
+        int maxOrder = planScheduleMapper.selectMaxOrderIndex(planId, newDay);
+        if (newOrder > maxOrder + 1) {
+            newOrder = maxOrder + 1;
+        }
+        log.info("maxOrder: {}, newOrder: {}", maxOrder, newOrder);
+
+        // CASE A: 다른 날짜로 이동할 때
+        if (currentDay != newDay) {
+            // 1. [원래 날짜] 내 뒤에 있는 애들 앞으로 당기기 (-1)
+            planScheduleMapper.pullScheduleOrders(planId, currentDay, currentOrder);
+
+            // 2. [이사 갈 날짜] 들어갈 자리의 뒤에 있는 애들 뒤로 밀기 (+1)
+            planScheduleMapper.pushScheduleOrders(planId, newDay, newOrder);
+        }
+        // CASE B: 같은 날짜 내에서 순서만 바꿀 때
+        else {
+            if (currentOrder < newOrder) {
+                // 뒤로 이동 (예: 1번 -> 3번)
+                // : 1번과 3번 사이(2,3)를 앞으로(-1) 당김
+                planScheduleMapper.moveOrderBack(planId, currentDay, currentOrder, newOrder);
+            } else {
+                // 앞으로 이동 (예: 3번 -> 1번)
+                // : 1번과 3번 사이(1,2)를 뒤로(+1) 밈
+                planScheduleMapper.moveOrderFront(planId, currentDay, currentOrder, newOrder);
+            }
+        }
+
+        // 3. 위치 확정
+        schedule.setDayNumber(newDay);
+        schedule.setOrderIndex(newOrder);
+        planScheduleMapper.updateScheduleDayAndOrder(schedule);
+    }
+
+    private void validatePermission(Long planId, Long userId) {
+        PlanMember member = planMemberMapper.findByPlanIdAndUserId(planId, userId);
+
+        // 멤버가 아니거나, 권한이 VIEWER(보기 전용)라면 거절
+        if (member == null || "VIEWER".equals(member.getRole())) {
+            throw new AccessDeniedException("일정 수정 권한이 없습니다.");
+        }
+    }
+}

--- a/src/main/resources/mapper/PlanScheduleMapper.xml
+++ b/src/main/resources/mapper/PlanScheduleMapper.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.trip.aslung.plan.model.mapper.PlanScheduleMapper">
+
+    <insert id="createSchedule" parameterType="com.trip.aslung.plan.model.dto.PlanSchedule"
+            useGeneratedKeys="true" keyProperty="scheduleId">
+
+        <selectKey keyProperty="orderIndex" resultType="int" order="BEFORE">
+            SELECT IFNULL(MAX(order_index), -1) + 1
+            FROM plan_schedules
+            WHERE plan_id = #{planId}
+            AND day_number = #{dayNumber}
+        </selectKey>
+
+        INSERT INTO plan_schedules (
+        plan_id,
+        place_id,
+        day_number,
+        order_index,
+        memo
+        ) VALUES (
+        #{planId},
+        #{placeId},
+        #{dayNumber},
+        #{orderIndex},
+        #{memo}
+        )
+    </insert>
+
+    <update id="updateSchedule" parameterType="com.trip.aslung.plan.model.dto.PlanSchedule">
+        UPDATE plan_schedules
+        <set>
+            <if test="placeId != null">place_id = #{placeId},</if>
+            <if test="memo != null">memo = #{memo},</if>
+            updated_at = NOW()
+        </set>
+        WHERE schedule_id = #{scheduleId}
+        AND plan_id = #{planId}
+    </update>
+
+    <delete id="deleteSchedule">
+        DELETE FROM plan_schedules
+        WHERE schedule_id = #{scheduleId}
+    </delete>
+
+    <select id="findById" resultType="com.trip.aslung.plan.model.dto.PlanSchedule">
+        SELECT * FROM plan_schedules WHERE schedule_id = #{scheduleId}
+    </select>
+
+    <update id="pullScheduleOrders">
+        UPDATE plan_schedules
+        SET order_index = order_index - 1
+        WHERE plan_id = #{planId}
+          AND day_number = #{dayNumber}
+          AND order_index &gt; #{startOrder}
+    </update>
+
+    <update id="pushScheduleOrders">
+        UPDATE plan_schedules
+        SET order_index = order_index + 1
+        WHERE plan_id = #{planId}
+          AND day_number = #{dayNumber}
+          AND order_index &gt;= #{startOrder}
+    </update>
+
+    <update id="updateScheduleDayAndOrder">
+        UPDATE plan_schedules
+        SET
+            day_number = #{dayNumber},
+            order_index = #{orderIndex},
+            updated_at = NOW()
+        WHERE schedule_id = #{scheduleId}
+    </update>
+
+    <update id="moveOrderBack">
+        UPDATE plan_schedules
+        SET order_index = order_index - 1
+        WHERE plan_id = #{planId} AND day_number = #{day}
+          AND order_index &gt; #{oldOrder}
+          AND order_index &lt;= #{newOrder}
+    </update>
+
+    <update id="moveOrderFront">
+        UPDATE plan_schedules
+        SET order_index = order_index + 1
+        WHERE plan_id = #{planId} AND day_number = #{day}
+          AND order_index &gt;= #{newOrder}
+          AND order_index &lt; #{oldOrder}
+    </update>
+
+    <select id="selectMaxOrderIndex" resultType="int">
+        SELECT IFNULL(MAX(order_index), -1)
+        FROM plan_schedules
+        WHERE plan_id = #{planId} AND day_number = #{dayNumber}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## 📌관련 이슈
- closed: #19

## 💥작업 내용
**1. 세부 일정(Schedule) CRUD API 구현**

- **등록 (`POST`)**: `selectKey`를 사용하여 해당 날짜의 마지막 순서(`order_index`)를 자동 계산하여 저장
- **수정 (`PATCH`)**: 메모(`memo`) 및 장소(`placeId`) 정보 수정 (Dynamic Update)
- **삭제 (`DELETE`)**: 일정 삭제 시, 후순위 일정들의 번호를 자동으로 -1씩 당기는(`Pull`) 로직 적용하여 순서 끊김 방지
- **이동 (`PATCH`)**: 다른 날짜로 이동하거나, 같은 날짜 내에서 순서를 변경하는 **Drag & Drop** 로직 구현
    - `Pull & Push` 알고리즘을 적용하여 이동 시 빈자리는 메꾸고, 들어갈 자리는 확보하도록 구현
    - DB 정합성을 위해 트랜잭션(`@Transactional`) 처리

**2. 코드 구조 및 안정성 개선**

- **Controller 분리**: `PlanController`의 비대화를 막기 위해 `PlanScheduleController`로 분리 및 계층형 URL 설계 (`/plans/{planId}/schedules`)
- **DTO 분리**: 요청 목적에 맞게 `ScheduleAddRequest`, `ScheduleUpdateRequest`, `ScheduleMoveRequest`로 DTO 세분화
- **MyBatis 매핑 최적화**: XML 내 특수문자(`&gt;`, `&lt;`) 처리 및 파라미터 바인딩 오류 수정

## ✨참고 사항
- **이동(Move) 로직**: 단순 1:1 교환(Swap)이 아니라, 리스트 사이로 끼어드는 **Move** 방식으로 구현되어 프론트엔드 드래그 앤 드롭 동작과 일치합니다.
- **순서 관리**: 프론트엔드에서 등록 시 `orderIndex`를 보낼 필요가 없으며(서버 자동 처리), 삭제 시에도 별도의 재정렬 요청이 필요 없습니다.
- **테스트**: Postman을 통해 등록(3건) -> 수정 -> 이동(순서 변경) -> 삭제 시나리오 검증 완료했습니다.
