### PR TITLE
fix: 로그아웃, 일정 추가 시 장소 추가 로직 수정

### DIFF
--- a/src/main/java/com/trip/aslung/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/trip/aslung/config/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,27 @@
+package com.trip.aslung.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        // 1. 상태 코드를 401로 설정
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        // 2. 응답 타입을 JSON으로 설정
+        response.setContentType("application/json;charset=UTF-8");
+        // 3. JSON 메시지 작성
+        response.getWriter().write("{" +
+                "\"status\": 401," +
+                "\"error\": \"UNAUTHORIZED\"," +
+                "\"message\": \"인증 정보가 유효하지 않습니다. 다시 로그인 해주세요.\"" +
+                "}");
+    }
+}

--- a/src/main/java/com/trip/aslung/plan/controller/PlanController.java
+++ b/src/main/java/com/trip/aslung/plan/controller/PlanController.java
@@ -26,7 +26,7 @@ public class PlanController {
     public ResponseEntity<List<PlanListResponse>> getMyPlans(
             @AuthenticationPrincipal Long userId
     ){
-        List<PlanListResponse> myPlans = planService.getMyPlans(1L);
+        List<PlanListResponse> myPlans = planService.getMyPlans(userId);
         return ResponseEntity.ok(myPlans);
     }
 

--- a/src/main/java/com/trip/aslung/plan/controller/ScheduleController.java
+++ b/src/main/java/com/trip/aslung/plan/controller/ScheduleController.java
@@ -1,6 +1,7 @@
 package com.trip.aslung.plan.controller;
 
 import com.trip.aslung.plan.model.dto.PlanSchedule;
+import com.trip.aslung.plan.model.dto.ScheduleAddRequest;
 import com.trip.aslung.plan.model.dto.ScheduleMoveRequest;
 import com.trip.aslung.plan.model.dto.ScheduleUpdateRequest;
 import com.trip.aslung.plan.model.service.PlanScheduleService;
@@ -21,7 +22,7 @@ public class ScheduleController {
     public ResponseEntity<Void> addSchedule(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long planId,
-            @RequestBody PlanSchedule request
+            @RequestBody ScheduleAddRequest request
     ){
         planScheduleService.addSchedule(userId, planId, request);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/trip/aslung/plan/model/dto/Place.java
+++ b/src/main/java/com/trip/aslung/plan/model/dto/Place.java
@@ -1,0 +1,21 @@
+package com.trip.aslung.plan.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Place {
+    private Long placeId;         // PK (place_id)
+    private String kakaoMapId;    // 카카오맵 고유 ID (kakao_map_id)
+    private String name;          // 장소명
+    private String address;       // 주소
+    private String category;      // 카테고리
+    private double latitude;      // 위도 (lat)
+    private double longitude;     // 경도 (lng)
+    private String imageUrl;      // 이미지 URL
+}

--- a/src/main/java/com/trip/aslung/plan/model/dto/PlanSchedule.java
+++ b/src/main/java/com/trip/aslung/plan/model/dto/PlanSchedule.java
@@ -23,4 +23,6 @@ public class PlanSchedule {
     // DB 테이블에는 없지만, JOIN해서 가져온 데이터를 담을 용도
     private String placeName;   // places 테이블의 name
     private String category;    // places 테이블의 category
+    private Double latitude;  // 위도 (y)
+    private Double longitude; // 경도 (x)
 }

--- a/src/main/java/com/trip/aslung/plan/model/dto/ScheduleAddRequest.java
+++ b/src/main/java/com/trip/aslung/plan/model/dto/ScheduleAddRequest.java
@@ -1,0 +1,21 @@
+package com.trip.aslung.plan.model.dto;
+
+import lombok.Data;
+
+@Data
+public class ScheduleAddRequest {
+    private Long planId;
+    private int tripDay;
+    private Integer orderIndex;
+
+    // 2. 장소 관련 정보 (Kakao Map에서 오는 데이터)
+    private Long placeId;         // (선택) 우리 DB ID가 있다면
+    private String kakaoPlaceId;  // (필수) 카카오 장소 ID
+    private String placeName;     // 장소명
+    private String address;       // 주소
+    private double lat;           // mapy (위도)
+    private double lng;           // mapx (경도)
+    private String category;      // 카테고리
+    private String imageUrl;      // 이미지 URL
+    private String memo;
+}

--- a/src/main/java/com/trip/aslung/plan/model/mapper/PlaceMapper.java
+++ b/src/main/java/com/trip/aslung/plan/model/mapper/PlaceMapper.java
@@ -1,0 +1,16 @@
+package com.trip.aslung.plan.model.mapper;
+
+import com.trip.aslung.plan.model.dto.Place;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface PlaceMapper {
+    Place findByKakaoMapId(String kakaoMapId);
+    Place findByNameAndLocation(@Param("name") String name,
+                                @Param("lat") double lat,
+                                @Param("lng") double lng);
+    void updateKakaoMapId(@Param("placeId") Long placeId,
+                          @Param("kakaoMapId") String kakaoMapId);
+    void savePlace(Place placeDto);
+}

--- a/src/main/java/com/trip/aslung/plan/model/mapper/PlanScheduleMapper.java
+++ b/src/main/java/com/trip/aslung/plan/model/mapper/PlanScheduleMapper.java
@@ -1,7 +1,10 @@
 package com.trip.aslung.plan.model.mapper;
 
+import com.trip.aslung.plan.model.dto.Place;
 import com.trip.aslung.plan.model.dto.PlanSchedule;
+import com.trip.aslung.plan.model.dto.ScheduleAddRequest;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
@@ -9,7 +12,7 @@ import java.util.List;
 public interface PlanScheduleMapper {
 
     PlanSchedule findById(Long scheduleId);
-    void createSchedule(PlanSchedule planSchedule);
+    void createSchedule(ScheduleAddRequest planSchedule);
     void updateSchedule(PlanSchedule planSchedule);
     void deleteSchedule(Long scheduleId);
     void pullScheduleOrders(Long planId, int dayNumber, int startOrder);

--- a/src/main/java/com/trip/aslung/plan/model/service/PlanScheduleService.java
+++ b/src/main/java/com/trip/aslung/plan/model/service/PlanScheduleService.java
@@ -1,13 +1,14 @@
 package com.trip.aslung.plan.model.service;
 
 import com.trip.aslung.plan.model.dto.PlanSchedule;
+import com.trip.aslung.plan.model.dto.ScheduleAddRequest;
 import com.trip.aslung.plan.model.dto.ScheduleMoveRequest;
 import com.trip.aslung.plan.model.dto.ScheduleUpdateRequest;
 
 import java.util.List;
 
 public interface PlanScheduleService {
-    void addSchedule(Long userId, Long planId, PlanSchedule request);
+    void addSchedule(Long userId, Long planId, ScheduleAddRequest request);
     void updateSchedule(Long userId, Long planId, Long scheduleId, ScheduleUpdateRequest request);
     void deleteSchedule(Long userId, Long planId, Long scheduleId);
     void moveSchedule(Long userId, Long planId, Long scheduleId, ScheduleMoveRequest request);

--- a/src/main/java/com/trip/aslung/planMember/controller/PlanMemberController.java
+++ b/src/main/java/com/trip/aslung/planMember/controller/PlanMemberController.java
@@ -1,6 +1,8 @@
 package com.trip.aslung.planMember.controller;
 
 import com.trip.aslung.planMember.model.dto.InviteRequest;
+import com.trip.aslung.planMember.model.dto.PlanMember;
+import com.trip.aslung.planMember.model.dto.PlanMemberResponse;
 import com.trip.aslung.planMember.model.service.PlanMemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Controller
 @Slf4j
@@ -17,6 +21,14 @@ public class PlanMemberController {
 
     private final PlanMemberService planMemberService;
 
+    @GetMapping
+    public ResponseEntity<List<PlanMemberResponse>> getMember(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long planId
+    ){
+        List<PlanMemberResponse> members = planMemberService.getMember(userId, planId);
+        return ResponseEntity.ok(members);
+    }
     @PostMapping
     public ResponseEntity<String> inviteMember(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/trip/aslung/planMember/model/dto/PlanMemberResponse.java
+++ b/src/main/java/com/trip/aslung/planMember/model/dto/PlanMemberResponse.java
@@ -1,0 +1,19 @@
+package com.trip.aslung.planMember.model.dto;
+
+import lombok.Data;
+
+@Data
+public class PlanMemberResponse {
+    private Long memberId;      // plan_members.member_id
+    private Long planId;        // plan_members.plan_id
+    private Long userId;        // plan_members.user_id
+
+    // User 정보 (JOIN으로 가져옴)
+    private String nickname;
+    private String profileImageUrl;
+    private String email;
+
+    // 멤버 상태 정보
+    private String role;        // OWNER, EDITOR, VIEWER
+    private String status;      // INVITED, JOINED
+}

--- a/src/main/java/com/trip/aslung/planMember/model/mapper/PlanMemberMapper.java
+++ b/src/main/java/com/trip/aslung/planMember/model/mapper/PlanMemberMapper.java
@@ -2,13 +2,16 @@ package com.trip.aslung.planMember.model.mapper;
 
 import com.trip.aslung.planMember.model.dto.InvitationResponse;
 import com.trip.aslung.planMember.model.dto.PlanMember;
+import com.trip.aslung.planMember.model.dto.PlanMemberResponse;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 @Mapper
 public interface PlanMemberMapper {
+    List<PlanMemberResponse> findMembersByPlanId(@Param("planId") Long planId);
     void insertPlanMember(PlanMember planMember);
     void deleteMember(Long planId, Long userId);
     void updateMemberStatus(Long planId, Long userId, String status);

--- a/src/main/java/com/trip/aslung/planMember/model/service/PlanMemberService.java
+++ b/src/main/java/com/trip/aslung/planMember/model/service/PlanMemberService.java
@@ -1,10 +1,13 @@
 package com.trip.aslung.planMember.model.service;
 
 import com.trip.aslung.planMember.model.dto.InvitationResponse;
+import com.trip.aslung.planMember.model.dto.PlanMember;
+import com.trip.aslung.planMember.model.dto.PlanMemberResponse;
 
 import java.util.List;
 
 public interface PlanMemberService {
+    List<PlanMemberResponse> getMember(Long userId, Long planId);
     void inviteMember(Long planId, Long ownerId, Long targetUserId);
     void kickMember(Long planId, Long ownerId, Long targetMemberId);
     void leavePlan(Long planId, Long userId);

--- a/src/main/java/com/trip/aslung/planMember/model/service/PlanMemberServiceImpl.java
+++ b/src/main/java/com/trip/aslung/planMember/model/service/PlanMemberServiceImpl.java
@@ -4,6 +4,7 @@ import com.trip.aslung.plan.model.dto.PlanDetailResponse;
 import com.trip.aslung.plan.model.mapper.PlanMapper;
 import com.trip.aslung.planMember.model.dto.InvitationResponse;
 import com.trip.aslung.planMember.model.dto.PlanMember;
+import com.trip.aslung.planMember.model.dto.PlanMemberResponse;
 import com.trip.aslung.planMember.model.mapper.PlanMemberMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +21,13 @@ public class PlanMemberServiceImpl implements PlanMemberService {
 
     private final PlanMemberMapper planMemberMapper;
     private final PlanMapper planMapper;
+
+    @Override
+    public List<PlanMemberResponse> getMember(Long userId, Long planId) {
+        PlanMember member = planMemberMapper.findByPlanIdAndUserId(userId, planId);
+        //if(member == null) throw new IllegalArgumentException("접근 권한 없습니다.");
+        return planMemberMapper.findMembersByPlanId(planId);
+    }
 
     @Override
     public void inviteMember(Long planId, Long ownerId, Long targetUserId) {

--- a/src/main/resources/mapper/Place.xml
+++ b/src/main/resources/mapper/Place.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.trip.aslung.plan.model.mapper.PlaceMapper">
+    <select id="findByKakaoMapId" resultType="com.trip.aslung.plan.model.dto.Place">
+        SELECT
+            place_id AS placeId,
+            kakao_map_id AS kakaoMapId,
+            name,
+            address,
+            category,
+            latitude,
+            longitude,
+            image_url AS imageUrl
+        FROM places
+        WHERE kakao_map_id = #{kakaoMapId}
+    </select>
+
+    <insert id="savePlace" useGeneratedKeys="true" keyProperty="placeId">
+        INSERT INTO places (
+            kakao_map_id, name, address, category, latitude, longitude, image_url
+        ) VALUES (
+                     #{kakaoMapId}, #{name}, #{address}, #{category}, #{latitude}, #{longitude}, #{imageUrl}
+                 )
+    </insert>
+
+    <select id="findByNameAndLocation" resultType="com.trip.aslung.plan.model.dto.Place">
+        SELECT * FROM places
+        WHERE name = #{name}
+          AND ABS(latitude - #{lat}) &lt; 0.0001
+          AND ABS(longitude - #{lng}) &lt; 0.0001
+            LIMIT 1
+    </select>
+
+    <update id="updateKakaoMapId">
+        UPDATE places
+        SET kakao_map_id = #{kakaoMapId}
+        WHERE place_id = #{placeId}
+    </update>
+</mapper>

--- a/src/main/resources/mapper/PlanMember.xml
+++ b/src/main/resources/mapper/PlanMember.xml
@@ -65,4 +65,22 @@
         SET is_public = #{isPublic},
             updated_at = NOW()  WHERE plan_id = #{planId}
     </update>
+
+    <select id="findMembersByPlanId" resultType="com.trip.aslung.planMember.model.dto.PlanMemberResponse">
+        SELECT
+            pm.member_id        AS memberId,
+            pm.plan_id          AS planId,
+            pm.user_id          AS userId,
+            pm.role             AS role,
+            pm.status           AS status,
+            u.nickname          AS nickname,
+            u.profile_image_url AS profileImageUrl,
+            u.email             AS email
+        FROM plan_members pm
+                 JOIN users u ON pm.user_id = u.user_id
+        WHERE pm.plan_id = #{planId}
+        ORDER BY
+            CASE WHEN pm.role = 'OWNER' THEN 1 ELSE 2 END, -- 방장을 맨 위로
+            pm.joined_at ASC -- 먼저 들어온 순서대로
+    </select>
 </mapper>

--- a/src/main/resources/mapper/PlanScheduleMapper.xml
+++ b/src/main/resources/mapper/PlanScheduleMapper.xml
@@ -11,7 +11,7 @@
             SELECT IFNULL(MAX(order_index), -1) + 1
             FROM plan_schedules
             WHERE plan_id = #{planId}
-            AND day_number = #{dayNumber}
+            AND day_number = #{tripDay}
         </selectKey>
 
         INSERT INTO plan_schedules (
@@ -23,7 +23,7 @@
         ) VALUES (
         #{planId},
         #{placeId},
-        #{dayNumber},
+        #{tripDay},
         #{orderIndex},
         #{memo}
         )


### PR DESCRIPTION
## 📌관련 이슈

- closed: #30

## 💥작업 내용

**1. 인증 예외 처리 및 로그아웃 고도화**

- **SecurityConfig 수정**: 인증 실패(유효하지 않은 토큰) 시 로그인 페이지 리다이렉트가 아닌, 명확한 **401 Unauthorized** JSON 응답을 반환하도록 `CustomAuthenticationEntryPoint` 적용.
- **로그아웃 API 개선**:
    - 서버 측 세션 및 `JSESSIONID` 쿠키 강제 삭제.
    - 응답으로 **카카오 로그아웃 URL**을 반환하여 프론트엔드에서 카카오 계정 세션까지 만료시킬 수 있도록 처리.

**2. 일정(Schedule) 및 장소(Place) 저장 로직 수정**

- **장소 중복 저장 방지 로직 구현 (`PlanService`)**:
    - 1차: `kakaoMapId`로 조회.
    - 2차: `kakaoMapId`가 없을 경우 `장소명` + `위도/경도`로 재조회하여 기존 데이터 재활용 (Data Double Check).
    - 기존 장소 활용 시 누락된 카카오 ID 업데이트, 없을 경우 신규 `INSERT`.
- **MyBatis Mapper 수정**:
    - `PlanScheduleMapper` XML 파라미터 불일치 수정 (`dayNumber` → `tripDay`).
    - `<selectKey>`를 활용하여 `order_index` 자동 증가 로직 적용.
- **DTO 수정**: `ScheduleAddRequest`에 `memo`, `orderIndex` 등 누락된 필드 추가.

## ✨참고 사항

- **로그아웃 흐름**: 클라이언트가 `/logout` 호출 → 백엔드가 카카오 로그아웃 URL 반환 → 클라이언트가 해당 URL로 리다이렉트(전체 로그아웃 완료).
- **장소 저장**: 일정 추가 시 우리 DB에 없는 장소라면 자동으로 `places` 테이블에 등록된 후 참조됩니다.