### PR TITLE
feature: WebSocket/stomp 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,10 @@
 			<artifactId>spring-cloud-aws-starter-s3</artifactId>
 			<version>3.1.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-websocket</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -105,6 +109,7 @@
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
+							<version>1.18.30</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>

--- a/src/main/java/com/trip/aslung/config/StompHandler.java
+++ b/src/main/java/com/trip/aslung/config/StompHandler.java
@@ -1,0 +1,46 @@
+package com.trip.aslung.config;
+
+import com.trip.aslung.util.JWTUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompHandler implements ChannelInterceptor {
+
+    private final JWTUtil jwtUtil; // 이미 만드신 그 Util!
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        // 1. 소켓 연결(CONNECT) 시점에 토큰 검증
+        if (StompCommand.CONNECT == accessor.getCommand()) {
+            String jwtToken = accessor.getFirstNativeHeader("Authorization");
+            log.info("⭐⭐⭐ WebSocket 연결 시 토큰 확인 : {}", jwtToken);
+
+            if (jwtToken != null && jwtToken.startsWith("Bearer ")) {
+                String token = jwtToken.substring(7);
+
+                // 2. 기존 JWTUtil로 검증
+                if (jwtUtil.validateToken(token)) {
+                    Long userId = jwtUtil.getUserId(token);
+                    // 3. 컨트롤러에서 사용할 수 있게 세션에 저장
+                    accessor.getSessionAttributes().put("userId", userId);
+                    log.info("인증 성공 - userId: {}", userId);
+                } else {
+                    log.error("토큰 검증 실패");
+                }
+            }
+        }
+        return message;
+    }
+}

--- a/src/main/java/com/trip/aslung/config/WebSocketConfig.java
+++ b/src/main/java/com/trip/aslung/config/WebSocketConfig.java
@@ -1,0 +1,40 @@
+package com.trip.aslung.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompHandler stompHandler;
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        // 메시지가 들어올 때 인터셉터가 가로채서 인증하도록 설정
+        registration.interceptors(stompHandler);
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // client <> Server 연결 엔드포인트
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 클라이언트가 메시지를 보낼 때 Prefix
+        registry.setApplicationDestinationPrefixes("/app");
+
+        // 클라이언트가 메시지를 구독, 서버가 메세지 발행 Prefix
+        registry.enableSimpleBroker("/topic");
+    }
+}

--- a/src/main/java/com/trip/aslung/plan/controller/ScheduleSocketController.java
+++ b/src/main/java/com/trip/aslung/plan/controller/ScheduleSocketController.java
@@ -1,0 +1,85 @@
+package com.trip.aslung.plan.controller;
+
+import com.trip.aslung.plan.model.dto.ScheduleAddRequest;
+import com.trip.aslung.plan.model.dto.ScheduleMoveRequest;
+import com.trip.aslung.plan.model.dto.ScheduleUpdateRequest;
+import com.trip.aslung.plan.model.service.PlanScheduleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+import java.util.Map;
+
+@Controller
+@RequiredArgsConstructor
+public class ScheduleSocketController {
+
+    private final PlanScheduleService planScheduleService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    // 세부 일정 등록
+    @MessageMapping("/plans/{planId}/schedules/add")
+    public void addSchedule(
+            @DestinationVariable Long planId,
+            ScheduleAddRequest request,
+            Principal principal // Security 설정 시 인증된 사용자 ID를 가져올 수 있음
+    ) {
+        // userId 추출 (Security 설정에 따라 principal.getName() 등 활용)
+        Long userId = Long.parseLong(principal.getName());
+
+        planScheduleService.addSchedule(userId, planId, request);
+
+        // 변경 사항을 해당 플랜을 구독 중인 모든 사용자에게 전송
+        messagingTemplate.convertAndSend("/sub/plans/" + planId, "SCHEDULE_ADDED");
+    }
+
+    // 세부 일정 수정
+    @MessageMapping("/plans/{planId}/schedules/{scheduleId}/update")
+    public void updateSchedule(
+            @DestinationVariable Long planId,
+            @DestinationVariable Long scheduleId,
+            ScheduleUpdateRequest request,
+            Principal principal
+    ) {
+        Long userId = Long.parseLong(principal.getName());
+        planScheduleService.updateSchedule(userId, planId, scheduleId, request);
+
+        messagingTemplate.convertAndSend("/sub/plans/" + planId, "SCHEDULE_UPDATED");
+    }
+
+    // 세부 일정 삭제
+    @MessageMapping("/plans/{planId}/schedules/{scheduleId}/delete")
+    public void deleteSchedule(
+            @DestinationVariable Long planId,
+            @DestinationVariable Long scheduleId,
+            Principal principal
+    ) {
+        Long userId = Long.parseLong(principal.getName());
+        planScheduleService.deleteSchedule(userId, planId, scheduleId);
+
+        messagingTemplate.convertAndSend("/sub/plans/" + planId, "SCHEDULE_DELETED");
+    }
+
+    // 순서 변경
+    @MessageMapping("/plans/{planId}/schedules/{scheduleId}/move")
+    public void moveScheduleOrder(
+            @DestinationVariable Long planId,
+            @DestinationVariable Long scheduleId,
+            ScheduleMoveRequest request,
+            Principal principal
+    ) {
+        Long userId = Long.parseLong(principal.getName());
+        planScheduleService.moveSchedule(userId, planId, scheduleId, request);
+
+        messagingTemplate.convertAndSend("/sub/plans/" + planId, "SCHEDULE_MOVED");
+    }
+
+    // 새로고침 신호 전달
+    @MessageMapping("/plans/{planId}/update")
+    public void broadcastUpdate(@DestinationVariable Long planId, Map<String, Object> payload) {
+        messagingTemplate.convertAndSend("/topic/plans/" + planId, payload);
+    }
+}

--- a/src/main/java/com/trip/aslung/plan/model/dto/SocketEventDTO.java
+++ b/src/main/java/com/trip/aslung/plan/model/dto/SocketEventDTO.java
@@ -1,0 +1,16 @@
+package com.trip.aslung.plan.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SocketEventDTO {
+    private String type;     // "ADD", "UPDATE", "DELETE"
+    private Long planId;     // 어느 여행 계획인지
+    private Object data;     // 실제 일정 객체나 삭제된 ID
+}


### PR DESCRIPTION
## 📌관련 이슈

- closed: #35

## 💥작업 내용

- **WebSocket/STOMP 환경 설정 추가**
    - `WebSocketConfig`를 통해 STOMP 엔드포인트(`/ws-stomp`) 및 메시지 브로커(`/sub`, `/pub`) 설정
- **실시간 일정 관리를 위한 `ScheduleSocketController` 구현**
    - 일정 등록, 수정, 삭제, 순서 변경 시 해당 플랜을 구독 중인 모든 사용자에게 실시간 변경 알림(Broadcasting) 전송
- **기존 비즈니스 로직 재사용**
    - `PlanScheduleService`를 주입받아 기존 REST API와 동일한 검증 및 저장 로직을 유지하며 실시간성 추가
- **Spring Security 통합**
    - `Principal` 객체를 통해 웹소켓 연결 세션에서도 인증된 사용자 정보를 안전하게 처리

## ✨참고 사항

- **메시지 발행/구독 구조**
    - **Subscribe**: `/sub/plans/{planId}` (클라이언트가 해당 경로를 구독하여 변경 사항 수신)
    - **Publish**: `/pub/plans/{planId}/schedules/{action}` (클라이언트가 변경 요청을 보낼 때 사용)
- **추후 개선 사항**
    - 현재는 단순 알림 문자열(`SCHEDULE_UPDATED` 등)을 전송하고 있으나, 프론트엔드 요구사항에 따라 변경된 DTO 객체를 직접 전송하는 방식으로 고도화 가능합니다.
- **테스트 방법**
    - APIC 또는 Postman의 WebSocket 기능을 통해 `/ws-stomp` 연결 후 정상 브로드캐스팅 여부 확인 완료했습니다