### PR TITLE
refactor: 플랜 생성 리팩토링

### DIFF
--- a/src/main/java/com/trip/aslung/config/StompHandler.java
+++ b/src/main/java/com/trip/aslung/config/StompHandler.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class StompHandler implements ChannelInterceptor {
 
-    private final JWTUtil jwtUtil; // 이미 만드신 그 Util!
+    private final JWTUtil jwtUtil;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {

--- a/src/main/java/com/trip/aslung/plan/controller/PlanController.java
+++ b/src/main/java/com/trip/aslung/plan/controller/PlanController.java
@@ -63,6 +63,7 @@ public class PlanController {
             @AuthenticationPrincipal Long userId,
             @PathVariable(("planId")) Long planId
     ){
+        log.info("plan Id : {}", planId);
         planService.deletePlan(userId, planId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/trip/aslung/plan/model/mapper/PlanMapper.java
+++ b/src/main/java/com/trip/aslung/plan/model/mapper/PlanMapper.java
@@ -15,6 +15,6 @@ public interface PlanMapper {
     List<PlanSchedule> selectPlanSchedules(Long planId);
     void insertPlan(Plan plan);
     void updatePlan(Plan plan);
-    void deletePlan(Long planId);
+    void deletePlan(Long planId, Long userId);
     void updatePlanVisibility(Long planId, boolean isPublic);
 }

--- a/src/main/java/com/trip/aslung/plan/model/service/PlanServiceImpl.java
+++ b/src/main/java/com/trip/aslung/plan/model/service/PlanServiceImpl.java
@@ -67,11 +67,12 @@ public class PlanServiceImpl implements PlanService {
         // 1. 플랜 생성
         Plan plan = new Plan();
         plan.setUserId(userId);
+        String regionsStr = "";
         if (request.getRegions() != null && !request.getRegions().isEmpty()) {
-            String regionsStr = String.join(",", request.getRegions());
-            plan.setRegionName(regionsStr);
+            regionsStr = String.join(",", request.getRegions());
         }
-        plan.setTitle(request.getRegions() + " 여행");
+        plan.setRegionName(regionsStr);
+        plan.setTitle(regionsStr + " 여행");
         plan.setStartDate(request.getStartDate());
         plan.setEndDate(request.getEndDate());
         plan.setIsPublic(request.getIsPublic() != null ? request.getIsPublic() : false);
@@ -136,7 +137,7 @@ public class PlanServiceImpl implements PlanService {
         }
 
         // 소프트 삭제 => 여행기 삭제 로직 필요
-        planMapper.deletePlan(planId);
+        planMapper.deletePlan(planId, userId);
     }
 
     @Override

--- a/src/main/resources/mapper/Plan.xml
+++ b/src/main/resources/mapper/Plan.xml
@@ -65,13 +65,15 @@
             title,
             start_date,
             end_date,
-            is_public
+            is_public,
+            region_name
         ) VALUES (
                      #{userId},
                      #{title},
                      #{startDate},
                      #{endDate},
-                     #{isPublic}
+                     #{isPublic},
+                     #{regionName}
                  )
     </insert>
 


### PR DESCRIPTION
## 📌관련 이슈

- closed: #49

## 💥작업 내용

**1. 플랜 생성(Create) 로직 수정**

- `Plan` DTO의 `regionList`가 DB 저장 시 문자열(`regionName`)로 변환되었으나, MyBatis 쿼리 파라미터 매핑 오류로 저장이 누락되던 문제를 수정했습니다.
- `INSERT` 쿼리에 `region_name` 컬럼을 명시적으로 추가했습니다.

**2. 플랜 삭제(Delete) 로직 수정**

- 플랜 삭제(`UPDATE set deleted_at = now()`) 시 `planId`와 `userId`를 함께 검증해야 했으나, `userId` 파라미터가 매퍼에 전달되지 않아 삭제가 동작하지 않던 문제를 수정했습니다.
- Mapper 인터페이스에 `@Param` 어노테이션을 추가하여 파라미터 바인딩을 명확히 했습니다.

**3. WebSocket(STOMP) 인증 보안 강화**

- 기존에는 토큰 검증 실패 시 로그만 출력하고 연결을 허용하던 보안 취약점이 있었습니다.
- `StompHandler`에서 토큰이 없거나(`Bearer undefined` 포함), 만료/위조된 토큰일 경우 `AccessDeniedException`을 발생시켜 **소켓 연결을 즉시 거부**하도록 변경했습니다.
- JWT 예외 상황(만료, 서명 오류 등)에 대한 디버깅 로그를 구체화했습니다.

## ✨참고 사항
- **프론트엔드 연동 시:** 소켓 연결 시 인증에 실패하면 이제 연결이 끊어지거나 에러 이벤트가 발생합니다. 프론트 쪽에서 해당 에러 발생 시 로그인 페이지로 리다이렉트 하는 로직 확인이 필요합니다.
- DB 스키마 변경 사항은 없습니다.