### PR TITLE
refactor:카테고리 관련 최신화

### DIFF
--- a/src/main/resources/mapper/review/ReviewMapper.xml
+++ b/src/main/resources/mapper/review/ReviewMapper.xml
@@ -113,11 +113,13 @@
             ps.day_number AS dayNumber,
             ps.order_index AS orderIndex,
             pl.name AS placeName,
-            pl.category,
+            ct.content_type_name AS category, -- 기존 pl.category 대신 테이블 조인 후 이름 추출
             r.comment AS memo,
             IFNULL(r.rating, 0) AS rating
         FROM plan_schedules ps
                  JOIN places pl ON ps.place_id = pl.place_id
+            -- 카테고리 이름을 가져오기 위한 JOIN 추가
+                 JOIN contenttypes ct ON pl.content_type_id = ct.content_type_id
                  LEFT JOIN reviews r ON ps.schedule_id = r.plan_schedule_id
         WHERE ps.plan_id = #{planId}
         ORDER BY ps.day_number, ps.order_index


### PR DESCRIPTION
## 📌관련 이슈
- closed: #70

## 💥 작업 내용
- **리뷰 불러오기 500 에러 수정**
    - `plan_id` 기반 스케줄 조회 시, 존재하지 않는 `places.category` 컬럼 참조로 인한 쿼리 오류 해결
- **DB 스키마 변경 사항 반영 (JOIN 구조 개선)**
    - `places` 테이블의 카테고리 구조 변경(`content_type_id`)에 따라 `contenttypes` 테이블과 **JOIN** 수행
    - 기존 `category` 필드에 실제 카테고리 명칭(`content_type_name`)이 담기도록 쿼리 수정
- **데이터 정합성 확보**
    - `IFNULL`을 사용하여 리뷰 점수가 없는 경우 기본값(0)을 반환하도록 유지

## ✨ 참고 사항
- **DTO 매핑**: `PostScheduleDto`의 `category` 필드에 `content_type_name` 값이 정상적으로 매핑되도록 Alias 처리를 완료했습니다.
- **JOIN 방식**: 현재 모든 장소는 카테고리 ID를 가진다는 가정하에 `JOIN`을 사용했으나, 카테고리 정보가 없는 데이터가 존재할 경우 `LEFT JOIN` 검토가 필요할 수 있습니다.